### PR TITLE
Support for Routing Instances

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "communities": {
       "flake": false,
       "locked": {
-        "lastModified": 1706695952,
-        "narHash": "sha256-FlbOBX/+/LLmoqMJLvu59XuHYmiohIhDc1VjkZu4Wzo=",
+        "lastModified": 1719412992,
+        "narHash": "sha256-WYcu4m9qytW5chFC8ZocDhvMflLIwsLkjz/z5ybjYlI=",
         "owner": "NLNOG",
         "repo": "lg.ring.nlnog.net",
-        "rev": "20f9a9f3da8b1bc9d7046e88c62df4b41b4efb99",
+        "rev": "41cf616bae6fba597d074a484aabf1bee9002fb5",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707092692,
-        "narHash": "sha256-ZbHsm+mGk/izkWtT4xwwqz38fdlwu7nUUKXTOmm4SyE=",
+        "lastModified": 1720418205,
+        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "faf912b086576fd1a15fca610166c98d47bc667e",
+        "rev": "655a58a72a6601292512670343087c2d75d859c1",
         "type": "github"
       },
       "original": {

--- a/frontend/src/cache.js
+++ b/frontend/src/cache.js
@@ -1,4 +1,14 @@
 export let routers;
+export let tables;
+
+async function get_routers() {
+	const resp = await fetch("/api/routers")
+	const json = await resp.json()
+
+	return Object.entries(json).sort((a, b) => a[1].client_name > b[1].client_name)
+}
+
 export const initCache = async () => {
-	routers = await fetch("/api/routers").then(resp => resp.json());
+	routers = await get_routers();
+	tables = await fetch("/api/routing-instances").then(resp => resp.json());
 };

--- a/frontend/src/resultsView.js
+++ b/frontend/src/resultsView.js
@@ -93,15 +93,15 @@ const processResults = (results) => {
 	// stage 1, combine pre- and post-policy adj-in tables
 	// start out with PostPolicy
 	const preAndPostPolicy = {};
-	const preAndPostPolicyKey = route => `${route.from_client}:${route.peer_address}:${route.net}`;
+	const preAndPostPolicyKey = route => `${route.session_id.from_client}:${route.session_id.peer_address}:${route.net}`;
 	for (let route of routeResults) {
-		if (route.table === "PostPolicyAdjIn") {
+		if (route.type === "PostPolicyAdjIn") {
 			preAndPostPolicy[preAndPostPolicyKey(route)] = route;
 		}
 	}
 	// add routes which are _only_ in PrePolicy => have not been accepted
 	for (let route of routeResults) {
-		if (route.table === "PrePolicyAdjIn") {
+		if (route.type === "PrePolicyAdjIn") {
 			const key = preAndPostPolicyKey(route);
 			if (!preAndPostPolicy[key]) {
 				preAndPostPolicy[key] = route;
@@ -173,7 +173,7 @@ export const resultsView = async (query) => {
 
 	const param_router = searchParams.get("Router");
 	if (param_router !== null) {
-		searchParams.set("Router", Object.values(routers).find(router => router.client_name == param_router).router_id);
+		searchParams.set("Router", routers.find(router => router[1].client_name == param_router)[1].router_id);
 	}
 
 	render(resultsTemplate(query, { routeResults: [], as_names: {} }, false), document.getElementById('content'));

--- a/frontend/src/search.js
+++ b/frontend/src/search.js
@@ -1,6 +1,6 @@
 import { html, render } from 'lit-html';
 import { go } from './router.js';
-import { routers } from './cache.js';
+import { routers, tables } from './cache.js';
 
 const modes = ["MostSpecific", "Exact", "OrLonger", "Contains"];
 
@@ -10,16 +10,36 @@ const formSubmit = (e) => {
 	let val = data.get("input-field");
 	const mode = data.get("query-mode");
 	const router = data.get("router-sel");
+	const table = data.get("table-sel");
+
 	let res = "#/";
+	let filter = [];
 	if (val !== "") {
 		res += `${mode}/${val}`;
 	}
 	if (router != "all") {
-		res += `?Router=${router}`;
+		filter.push(`Router=${router}`);
 	}
+	if (typeof table !== "undefined" && table != "default") {
+		filter.push(`route_distinguisher=${table}`);
+	}
+	if (filter.length > 0) {
+		res += "?" + filter.join("&");
+	}
+
 	window.location.hash = res;
 	return false;
 };
+
+function deduplicated_routing_tables(tables) {
+    return [...new Set(
+        Object.values(tables)
+            .flat()
+            .map(JSON.stringify)
+    )]
+    .toSorted()
+    .map(json_string => Array.from(JSON.parse(json_string)))
+}
 
 export const searchTemplate = ([ mode, ip, optionsString ]) => html`
 	<form id="input" @submit=${formSubmit}>
@@ -31,10 +51,26 @@ export const searchTemplate = ([ mode, ip, optionsString ]) => html`
 		<input name="input-field" id="input-field" type="text" spellcheck=false" autocomplete="new-password" autocorrect="off" autocapitalize="off" placeholder="Enter an IP address, prefix or DNS name..." value=${!!ip ? ip : ``} />
 		<select name="router-sel" id="router-sel" @change=${() => document.getElementById("input-submit").click()}>
 			<option value="all">on all</option>
-			${[...new Set(Object.values(routers).map(router => router.client_name))].map(name => html`
+			${[...new Set(routers.map(router => router[1].client_name))]
+				.map(name => html`
 				<option value=${name} ?selected=${(new URLSearchParams(optionsString)).get("Router") === name}>on ${name}</option>
 			`)}
 		</select>
+        ${(deduplicated_routing_tables(tables).length > 1) ?
+            html`
+            <select name="table-sel" id="table-sel"
+                @change=${() => document.getElementById("input-submit").click()}
+                >
+                ${deduplicated_routing_tables(tables).map(entry => {
+                        let [rd, name] = entry
+                        name = name ?? rd
+                        return html`
+                            <option value=${rd} ?selected=${(new URLSearchParams(optionsString)).get("route_distinguisher") === rd}>${name}</option>
+                        `
+                    })
+                }
+            </select>
+        ` : `` }
 		<input type="submit" id="input-submit" value="Go" />
 	</form>
 `;

--- a/manual/src/SUMMARY.md
+++ b/manual/src/SUMMARY.md
@@ -10,5 +10,6 @@
 - [Configuration](./configuration/README.md)
   - [Junos using BMP](./configuration/bmp-junos.md)
   - [bird2 using BGP](./configuration/bgp-bird2.md)
+  - [VRF/Routing-Instances](./configuration/routing-instances.md)
 - [Appendix](./appendix/README.md)
   - [NixOS specialArgs pattern](./appendix/nixos-specialArgs-pattern.md)

--- a/manual/src/configuration/README.md
+++ b/manual/src/configuration/README.md
@@ -57,3 +57,4 @@ Valid options for BGP peer config:
 - `asn` (required): AS Number advertised to peer
 - `router_id` (required): Router ID advertised to peer
 - `name_override` (optional): Use this string instead of the hostname advertised in the [BGP hostname capability](https://www.ietf.org/archive/id/draft-walton-bgp-hostname-capability-02.txt)
+- `route_distinguisher` (optional): Routes belonging to this route-distinguisher are advertised in the default table. See [VRF/Routing-Instances](./routing-instances.md) for more information

--- a/manual/src/configuration/routing-instances.md
+++ b/manual/src/configuration/routing-instances.md
@@ -1,0 +1,25 @@
+# VRF/Routing-Instances
+
+VRFs/Routing-Instances are supported out of the box and do not need any
+configuration for BMP- and MPBGP-Sessions.
+
+## BGP Session in VRF
+
+If the BGP Session (on the router) belongs to a routing-instance fernglas should
+be configured to belong to the same RI:
+
+```
+# config.yml
+collectors:
+    bgp_peer:
+        bind: "192.0.2.1:179"
+        default_peer_config:
+            asn: 64496
+            router_id: 192.0.2.1
+            # same RD as peer
+            route_distinguisher: 192.1.2.5:100
+```
+
+If this configuration is missing routes would be added as if they were in the
+default routing-instance instead of the routing-instance (and consequently matched when
+querying for routes of the default routing-instance.)

--- a/src/api.rs
+++ b/src/api.rs
@@ -271,7 +271,7 @@ async fn query<T: Store>(
                 }
             }
             if let Some(asn_dns_zone) = &cfg.asn_dns_zone {
-                for asn in route.attrs.as_path.into_iter().flat_map(|x| x) {
+                for asn in route.attrs.as_path.into_iter().flatten() {
                     if have_asn.insert(asn) {
                         let resolver = resolver.clone();
                         let asn_dns_zone = asn_dns_zone.clone();
@@ -286,10 +286,7 @@ async fn query<T: Store>(
                                             .next()
                                             .and_then(|data| std::str::from_utf8(data).ok())
                                             .and_then(|s| {
-                                                s.split(" | ")
-                                                    .skip(4)
-                                                    .next()
-                                                    .map(|name| name.to_string())
+                                                s.split(" | ").nth(4).map(|name| name.to_string())
                                             })
                                     })
                                 })
@@ -298,7 +295,7 @@ async fn query<T: Store>(
                     }
                 }
             }
-            for community in route.attrs.communities.into_iter().flat_map(|x| x) {
+            for community in route.attrs.communities.into_iter().flatten() {
                 if have_community.insert(community) {
                     let community_str = format!("{}:{}", community.0, community.1);
                     if let Some(lookup) = community_lists.regular.lookup(&community_str) {
@@ -311,7 +308,7 @@ async fn query<T: Store>(
                     }
                 }
             }
-            for large_community in route.attrs.large_communities.into_iter().flat_map(|x| x) {
+            for large_community in route.attrs.large_communities.into_iter().flatten() {
                 if have_large_community.insert(large_community) {
                     let large_community_str = format!(
                         "{}:{}:{}",
@@ -330,7 +327,7 @@ async fn query<T: Store>(
 
             futures
         })
-        .filter_map(|x| futures_util::future::ready(x))
+        .filter_map(futures_util::future::ready)
         .map(|result| {
             let json = serde_json::to_string(&result).unwrap();
             Ok::<_, Infallible>(format!("{}\n", json))

--- a/src/bgp_collector.rs
+++ b/src/bgp_collector.rs
@@ -50,7 +50,7 @@ pub async fn run_peer(
         .or(open_message.caps.iter().find_map(|x| {
             if let BgpCapability::CapFQDN(hostname, domainname) = x {
                 let mut name = hostname.to_string();
-                if domainname != "" {
+                if domainname.is_empty() {
                     name = format!("{}.{}", name, domainname);
                 }
                 Some(name)

--- a/src/bgpdumper.rs
+++ b/src/bgpdumper.rs
@@ -40,7 +40,7 @@ impl BgpDumper {
     }
     pub async fn start_active(&mut self) -> Result<BgpOpenMessage, BgpError> {
         let mut bom = self.params.open_message();
-        let mut buf = [255 as u8; 4096];
+        let mut buf = [255u8; 4096];
         let messagelen = match bom.encode_to(&self.params, &mut buf[19..]) {
             Err(e) => {
                 return Err(e);
@@ -58,7 +58,7 @@ impl BgpDumper {
         bom.decode_from(&self.params, &buf[..])?;
         debug!("{:?}", bom);
         self.params.hold_time = bom.hold_time;
-        self.params.caps = bom.caps.clone();
+        self.params.caps.clone_from(&bom.caps);
         self.params.check_caps();
         Ok(bom)
     }
@@ -67,8 +67,8 @@ impl BgpDumper {
         let slp = std::time::Duration::new((self.params.hold_time / 3) as u64, 0);
         let write = self.write.clone();
         tokio::task::spawn(async move {
-            let mut buf = [255 as u8; 19];
-            buf[0..16].clone_from_slice(&[255 as u8; 16]);
+            let mut buf = [255u8; 19];
+            buf[0..16].clone_from_slice(&[255u8; 16]);
             buf[16] = 0;
             buf[17] = 19;
             buf[18] = 4; //keepalive

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod bgp_collector;
 mod bgpdumper;
 pub mod bmp_collector;
 mod compressed_attrs;
+pub mod route_distinguisher;
 pub mod store;
 pub mod store_impl;
 pub mod table_impl;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,8 @@ async fn main() -> anyhow::Result<()> {
 
     futures.extend(
         cfg.collectors
-            .into_iter()
-            .map(|(_, collector)| match collector {
+            .into_values()
+            .map(|collector| match collector {
                 CollectorConfig::Bmp(cfg) => {
                     tokio::task::spawn(bmp_collector::run(cfg, store.clone(), shutdown_rx.clone()))
                 }

--- a/src/route_distinguisher.rs
+++ b/src/route_distinguisher.rs
@@ -1,0 +1,266 @@
+use zettabgp::afi::BgpRD;
+
+use serde::de::{self, Visitor};
+use serde::{Serialize, Serializer};
+use std::fmt::{self, Display};
+use std::net::Ipv4Addr;
+use std::str::FromStr;
+
+#[derive(Default, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub enum RouteDistinguisher {
+    #[default]
+    Default,
+    Type0 {
+        asn: u16,
+        value: u32,
+    },
+    Type1 {
+        ip: Ipv4Addr,
+        value: u16,
+    },
+    Type2 {
+        asn: u32,
+        value: u16,
+    },
+}
+
+impl RouteDistinguisher {
+    pub fn is_default(&self) -> bool {
+        *self == RouteDistinguisher::Default
+    }
+}
+
+static EXPECT_MESSAGE: &str = r#"expecting a route distinguisher in one of the following formats:
+Type0: "{2-byte ASN}:{4-byte value}" | u16:u32  (example: 2222:1000000)
+Type1: "{4-byte IP}:{2-byte value}"  | ipv4:u16 (example: "1.2.3.4:555")
+Type2: "{4-byte ASN}:{2-byte value}" | u32:u16  (example: "1000000:3232")"#;
+
+impl Serialize for RouteDistinguisher {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> de::Deserialize<'de> for RouteDistinguisher {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct RdVisitor;
+
+        impl<'de> Visitor<'de> for RdVisitor {
+            type Value = RouteDistinguisher;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str(EXPECT_MESSAGE)
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                value
+                    .parse::<RouteDistinguisher>()
+                    .map_err(|emsg| de::Error::invalid_value(de::Unexpected::Str(value), &emsg))
+            }
+        }
+
+        deserializer.deserialize_str(RdVisitor)
+    }
+}
+
+impl Display for RouteDistinguisher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RouteDistinguisher::Default => write!(f, "0:0"),
+            RouteDistinguisher::Type0 { asn, value } => write!(f, "{asn}:{value}"),
+            RouteDistinguisher::Type1 { ip, value } => write!(f, "{ip}:{value}"),
+            RouteDistinguisher::Type2 { asn, value } => write!(f, "{asn}:{value}"),
+        }
+    }
+}
+
+impl FromStr for RouteDistinguisher {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "0:0" {
+            return Ok(RouteDistinguisher::Default);
+        }
+        let (k, v) = s.split_once(':').ok_or(EXPECT_MESSAGE)?;
+
+        let v = v.parse::<u32>().map_err(|_| EXPECT_MESSAGE)?;
+
+        if let Ok(asn) = k.parse::<u32>() {
+            return if asn > u16::MAX.into() && v <= u16::MAX.into() {
+                Ok(RouteDistinguisher::Type2 {
+                    asn,
+                    value: v as u16,
+                })
+            } else if asn <= u16::MAX.into() {
+                Ok(RouteDistinguisher::Type0 {
+                    asn: asn as u16,
+                    value: v,
+                })
+            } else {
+                Err(EXPECT_MESSAGE)
+            };
+        }
+
+        if let Ok(ip) = k.parse::<Ipv4Addr>() {
+            if v <= u16::MAX.into() {
+                return Ok(RouteDistinguisher::Type1 {
+                    ip,
+                    value: v as u16,
+                });
+            }
+        }
+
+        Err(EXPECT_MESSAGE)
+    }
+}
+
+impl TryFrom<BgpRD> for RouteDistinguisher {
+    type Error = u16;
+
+    fn try_from(rd: BgpRD) -> Result<Self, Self::Error> {
+        let (high, low) = (rd.rdh, rd.rdl);
+        // everything zero => default routing instance
+        if high == 0 && low == 0 {
+            return Ok(RouteDistinguisher::Default);
+        }
+        let high = high.to_be_bytes();
+        let low = low.to_be_bytes();
+        // RD-Type is encoded in the 2 highest bytes (network endian)
+        Ok(match u16::from_be_bytes([high[0], high[1]]) {
+            0 => RouteDistinguisher::Type0 {
+                asn: u16::from_be_bytes([high[2], high[3]]),
+                value: rd.rdl,
+            },
+            1 => RouteDistinguisher::Type1 {
+                ip: Ipv4Addr::from([high[2], high[3], low[0], low[1]]),
+                value: u16::from_be_bytes([low[2], low[3]]),
+            },
+            2 => RouteDistinguisher::Type2 {
+                asn: u32::from_be_bytes([high[2], high[3], low[0], low[1]]),
+                value: u16::from_be_bytes([low[2], low[3]]),
+            },
+            e => return Err(e),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn decode_route_distingisher_from_string() {
+        let default = "0:0".parse();
+        let rd_type0 = "1234:5678".parse();
+        let rd_type1 = "10.0.0.1:5678".parse();
+        let rd_type2 = "70000:1234".parse();
+        assert_eq!(default, Ok(RouteDistinguisher::Default));
+        assert_eq!(
+            rd_type0,
+            Ok(RouteDistinguisher::Type0 {
+                asn: 1234,
+                value: 5678
+            })
+        );
+        assert_eq!(
+            rd_type1,
+            Ok(RouteDistinguisher::Type1 {
+                ip: Ipv4Addr::from([10, 0, 0, 1]),
+                value: 5678
+            })
+        );
+        assert_eq!(
+            rd_type2,
+            Ok(RouteDistinguisher::Type2 {
+                asn: 70000,
+                value: 1234
+            })
+        );
+
+        assert!("70000:70000".parse::<RouteDistinguisher>().is_err());
+        assert!("10.0.0.1:70000".parse::<RouteDistinguisher>().is_err());
+    }
+
+    #[test]
+    fn encode_route_distingisher() {
+        assert_eq!(
+            "1234:5678",
+            &RouteDistinguisher::Type0 {
+                asn: 1234,
+                value: 5678
+            }
+            .to_string()
+        );
+        assert_eq!(
+            "192.1.2.3:5678",
+            &RouteDistinguisher::Type1 {
+                ip: Ipv4Addr::from([192, 1, 2, 3]),
+                value: 5678
+            }
+            .to_string()
+        );
+        assert_eq!(
+            "70000:1234",
+            &RouteDistinguisher::Type2 {
+                asn: 70000,
+                value: 1234
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn decode_route_distingisher_from_zettabgp_rd() {
+        let default = BgpRD {
+            rdh: u32::from_be_bytes([0, 0, 0, 0]),
+            rdl: u32::from_be_bytes([0, 0, 0, 0]),
+        }
+        .try_into();
+        assert_eq!(default, Ok(RouteDistinguisher::Default));
+
+        let rd_type0 = BgpRD {
+            rdh: u32::from_be_bytes([0, 0, 0x12, 0x34]),
+            rdl: u32::from_be_bytes([0, 0, 0x56, 0x78]),
+        }
+        .try_into();
+        assert_eq!(
+            rd_type0,
+            Ok(RouteDistinguisher::Type0 {
+                asn: 0x1234,
+                value: 0x5678
+            })
+        );
+
+        let rd_type1 = BgpRD {
+            rdh: u32::from_be_bytes([0, 1, 10, 0]),
+            rdl: u32::from_be_bytes([0, 255, 0x56, 0x78]),
+        }
+        .try_into();
+        assert_eq!(
+            rd_type1,
+            Ok(RouteDistinguisher::Type1 {
+                ip: Ipv4Addr::from([10, 0, 0, 255]),
+                value: 0x5678
+            })
+        );
+
+        let rd_type2 = BgpRD {
+            rdh: u32::from_be_bytes([0, 2, 0x43, 0x21]),
+            rdl: u32::from_be_bytes([0x98, 0x76, 0x54, 0x32]),
+        }
+        .try_into();
+        assert_eq!(
+            rd_type2,
+            Ok(RouteDistinguisher::Type2 {
+                asn: 0x43219876,
+                value: 0x5432
+            })
+        );
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -3,7 +3,7 @@ use futures_util::Stream;
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use log::*;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::pin::Pin;
 use zettabgp::prelude::{BgpAddrV4, BgpAddrV6};
@@ -133,6 +133,8 @@ pub struct Query<T = IpNet> {
     pub limits: Option<QueryLimits>,
     #[serde(default)]
     pub as_path_regex: Option<String>,
+    #[serde(default)]
+    pub route_distinguisher: RouteDistinguisher,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -191,6 +193,8 @@ pub trait Store: Clone + Send + Sync + 'static {
     fn get_routes(&self, query: Query) -> Pin<Box<dyn Stream<Item = QueryResult> + Send>>;
 
     fn get_routers(&self) -> HashMap<SocketAddr, Client>;
+
+    fn get_routing_instances(&self) -> HashMap<SocketAddr, HashSet<RouteDistinguisher>>;
 
     async fn client_up(
         &self,

--- a/src/store_impl.rs
+++ b/src/store_impl.rs
@@ -191,7 +191,7 @@ impl Store for InMemoryStore {
                     let clients = clients.clone();
                     let sessions = sessions.clone();
                     async move {
-                        let client = match clients.lock().unwrap().get(&table.client_addr()) {
+                        let client = match clients.lock().unwrap().get(table.client_addr()) {
                             Some(v) => v.clone(),
                             None => {
                                 warn!("client is not connected");
@@ -199,7 +199,7 @@ impl Store for InMemoryStore {
                             }
                         };
                         let session = table.session_id().and_then(|session_id| {
-                            sessions.lock().unwrap().get(&session_id).cloned()
+                            sessions.lock().unwrap().get(session_id).cloned()
                         });
 
                         Some(QueryResult {

--- a/src/store_impl.rs
+++ b/src/store_impl.rs
@@ -22,7 +22,6 @@ pub struct InMemoryStore {
     clients: Arc<Mutex<HashMap<SocketAddr, Client>>>,
     sessions: Arc<Mutex<HashMap<SessionId, Session>>>,
     tables: Arc<Mutex<HashMap<TableSelector, InMemoryTable>>>,
-
     caches: Arc<Mutex<Caches>>,
 }
 
@@ -31,11 +30,13 @@ fn tables_for_client_fn(
 ) -> impl Fn(&(&TableSelector, &InMemoryTable)) -> bool + '_ {
     move |(k, _): &(_, _)| k.client_addr() == query_from_client
 }
+
 fn tables_for_session_fn(
     session_id: &SessionId,
 ) -> impl Fn(&(&TableSelector, &InMemoryTable)) -> bool + '_ {
     move |(k, _): &(_, _)| k.session_id() == Some(session_id)
 }
+
 impl InMemoryStore {
     fn tables_for_router_fn<'a>(
         &self,
@@ -196,6 +197,7 @@ impl Store for InMemoryStore {
                         let session = table.session_id().and_then(|session_id| {
                             sessions.lock().unwrap().get(&session_id).cloned()
                         });
+
                         Some(QueryResult {
                             state: table.route_state(),
                             net,

--- a/src/table_impl.rs
+++ b/src/table_impl.rs
@@ -27,10 +27,10 @@ impl NodeExt for Node<IpNet, Vec<(PathId, Arc<CompressedRouteAttrs>)>> {
             dyn Iterator<Item = (IpNet, &Vec<(PathId, Arc<CompressedRouteAttrs>)>)> + Send + '_,
         > = match net_query {
             None => Box::new(self.iter()),
-            Some(NetQuery::Exact(net)) => Box::new(self.exact(&net).map(|x| (*net, x)).into_iter()),
-            Some(NetQuery::MostSpecific(net)) => Box::new(self.longest_match(&net).into_iter()),
-            Some(NetQuery::Contains(net)) => Box::new(self.matches(&net)),
-            Some(NetQuery::OrLonger(net)) => Box::new(self.or_longer(&net)),
+            Some(NetQuery::Exact(net)) => Box::new(self.exact(net).map(|x| (*net, x)).into_iter()),
+            Some(NetQuery::MostSpecific(net)) => Box::new(self.longest_match(net).into_iter()),
+            Some(NetQuery::Contains(net)) => Box::new(self.matches(net)),
+            Some(NetQuery::OrLonger(net)) => Box::new(self.or_longer(net)),
         };
         Box::new(iter.flat_map(move |(net, routes)| {
             routes


### PR DESCRIPTION
This MR enhances fernglas to support routing-instances for BGP and BMP Sessions. Following three methods to gather routing-instance information have been implemented:

- BMP: evaluate RD in the MessagePeerHeader - no configuration necessary
- MP-BGP: routing-instances are signaled over VPNv4/VPNv6 address families - no configuration necessary
- BGP: Session itself belongs to a routing instance - BGP Session has to be assigned to a routing-instance in configuration

There has been a breaking change in the API to expose the routing-instance information. The frontend has been updated accordingly.

Possible outstanding improvement: Make Routing-Instance names configurable. Currently the Route-Distinguisher associated with the routing-instance is used as the name.